### PR TITLE
Fix incorrect LaTeX link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [Obsidian](./Obsidian.md)
 
-[LaTeX](./Latex.md)
+[LaTeX](./LaTeX.md)
 
 ## Linux相关
 


### PR DESCRIPTION
## Summary
- Correct LaTeX note link to use proper filename case

## Testing
- `markdownlint README.md` *(fails: command not found; `npm install -g markdownlint-cli` returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689558673f408322b6e0de3e166347f0